### PR TITLE
Separate serviceName and groupName

### DIFF
--- a/src/naming/NacosNamingService.cpp
+++ b/src/naming/NacosNamingService.cpp
@@ -104,7 +104,7 @@ void NacosNamingService::registerInstance
         _objectConfigData->_beatReactor->addBeatInfo(NamingUtils::getGroupedName(serviceName, groupName), beatInfo);
     }
 
-    _objectConfigData->_serverProxy->registerService(NamingUtils::getGroupedName(serviceName, groupName), groupName, instance);
+    _objectConfigData->_serverProxy->registerService(serviceName, groupName, instance);
 }
 
 void NacosNamingService::deregisterInstance


### PR DESCRIPTION
因为组合服务名与组名， 导致无法注册到指定的namespace