### PR TITLE
[BUG FIX] fix main process crash coredump when we use multithreads or…

### DIFF
--- a/examples/listenToKeys.cpp
+++ b/examples/listenToKeys.cpp
@@ -36,6 +36,8 @@ int main() {
     getchar();
     cout << "remove listener" << endl;
     n->removeListener("dqid", NULLSTR, theListener);//Cancel listening
+    int c;
+    while ((c = getchar()) != '\n' && c != EOF);
     getchar();
 
     return 0;

--- a/examples/subscribeServices.cpp
+++ b/examples/subscribeServices.cpp
@@ -40,11 +40,14 @@ int main() {
     n->registerInstance("ss", "127.0.0.1", 33);
     n->registerInstance("ss", "127.0.0.1", 34);
     cout << "Press any key to deregister services" << endl;
+    int c;
+    while ((c = getchar()) != '\n' && c != EOF);
     getchar();
 
     n->deregisterInstance("ss", "127.0.0.1", 33);
     n->deregisterInstance("ss", "127.0.0.1", 34);
     cout << "All instances Unregistered, press any key to finish testing" << endl;
+    while ((c = getchar()) != '\n' && c != EOF);
     getchar();
 
     return 0;

--- a/src/http/HTTPCli.cpp
+++ b/src/http/HTTPCli.cpp
@@ -79,6 +79,7 @@ void HTTPCli::HTTPBasicSettings(CURL *curlHandle) {
 
     /* interval time between keep-alive probes: 60 seconds */
     curl_easy_setopt(curlHandle, CURLOPT_TCP_KEEPINTVL, 60L);
+    curl_easy_setopt(curlHandle, CURLOPT_NOSIGNAL, 1);
 
 }
 
@@ -179,6 +180,7 @@ HttpResult HTTPCli::httpGetInternal
     curl_easy_reset(curlHandle);
     /* specify URL to get */
     curl_easy_setopt(curlHandle, CURLOPT_URL, Url.c_str());
+    curl_easy_setopt(curlHandle, CURLOPT_NOSIGNAL, 1);
 
     //Setup common parameters
     HTTPBasicSettings(curlHandle);
@@ -300,6 +302,7 @@ HttpResult HTTPCli::httpPostInternal
     curl_easy_reset(curlHandle);
     /* specify URL to get */
     curl_easy_setopt(curlHandle, CURLOPT_URL, Url.c_str());
+    curl_easy_setopt(curlHandle, CURLOPT_NOSIGNAL, 1);
 
     curl_easy_setopt(curlHandle, CURLOPT_CUSTOMREQUEST, "POST");
     curl_easy_setopt(curlHandle, CURLOPT_POSTFIELDS, paramValues.c_str());
@@ -430,6 +433,7 @@ HttpResult HTTPCli::httpPutInternal
     curl_easy_setopt(curlHandle, CURLOPT_CUSTOMREQUEST, "PUT");
     curl_easy_setopt(curlHandle, CURLOPT_POSTFIELDS, paramValues.c_str());
     curl_easy_setopt(curlHandle, CURLOPT_POSTFIELDSIZE, paramValues.size());
+    curl_easy_setopt(curlHandle, CURLOPT_NOSIGNAL, 1);
     //Setup common parameters
     HTTPBasicSettings(curlHandle);
 
@@ -540,6 +544,7 @@ HttpResult HTTPCli::httpDeleteInternal
 
     //clear-ups
     curl_easy_reset(curlHandle);
+    curl_easy_setopt(curlHandle, CURLOPT_NOSIGNAL, 1);
     /* specify URL to get */
     curl_easy_setopt(curlHandle, CURLOPT_URL, Url.c_str());
 


### PR DESCRIPTION
… some threads have sleep(#130)

1. we should not use signal to process libcurl timeout or some other events.because it is global, and will cause a lot of different problems like crash coredump.
2. After we set CURLOPT_NOSIGNAL, libcurl will use other ways to process timeout or other events.